### PR TITLE
chore: ci / cd skip if is the same version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,8 +33,12 @@ ifndef VERSION
 	$(error VERSION is required. Usage: make update-version VERSION=1.2.3)
 endif
 	@echo "Updating version to $(VERSION) using npm..."
-	@npm version $(VERSION) --no-git-tag-version
-	@echo "Version updated successfully"
+	@CURRENT_VERSION=$$(node -p "require('./package.json').version"); \
+	if [ "$$CURRENT_VERSION" = "$(VERSION)" ]; then \
+		echo "✓ Version is already $(VERSION), skipping update"; \
+	else \
+		npm version $(VERSION) --no-git-tag-version && echo "✓ Version updated successfully"; \
+	fi
 
 publish: build
 	@echo "Publishing to NPM..."


### PR DESCRIPTION
# Pull Request Checklist

## Description Dev notes

This pull request improves the `Makefile`'s version update process by adding a check to avoid unnecessary version updates when the target version is already set.

Improvements to version update logic:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L36-R41): Added a check to compare the current version in `package.json` with the target `VERSION` before running `npm version`, ensuring that the version update is only performed if needed. This prevents redundant updates and provides clearer feedback.

## Checklist

- [ ] Did you test manually the changes
