### PR TITLE
chore: skip format md

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ init: prepare-environment
 	npm install
 
 format:
-	@npx prettier --write --tab-width 2 "**/*.{yml,yaml,json,md}"
+	@npx prettier --write --tab-width 2 "**/*.{yml,yaml,json}"
 	@echo "Formatting Kotlin code..."
 	@ktlint --format "android/**/*.kt" || true
 


### PR DESCRIPTION
# Pull Request Checklist

## Description Dev notes

This pull request makes a minor update to the formatting process in the `Makefile`. The change removes Markdown files (`.md`) from the list of files that are automatically formatted with Prettier.

- Removed `.md` files from the Prettier formatting command to prevent automatic formatting of Markdown files in the `format` target of the `Makefile`.

## Checklist

- [ ] Did you test manually the changes
