### PR TITLE
fix(SP-2025-3125): fix version of gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -39,7 +39,7 @@ dependencies {
   implementation files('libs/pdf/Bixolon_pdf.aar')
 
   // Expo modules (provided by host app)
-  compileOnly 'expo.modules:modules-core'
+  compileOnly 'expo.modules:core:3.0.29'
 
   implementation 'androidx.core:core-ktx:1.12.0'
   implementation 'androidx.appcompat:appcompat:1.6.1'


### PR DESCRIPTION
# Pull Request Checklist

## Description Dev notes

This pull request makes a minor update to the Expo modules dependency in the Android build configuration. The change specifies the version of the `expo.modules:core` library to ensure consistent builds.

- Updated the `compileOnly` dependency for Expo modules in `android/build.gradle` to use `expo.modules:core:3.0.29` instead of the unversioned `expo.modules:modules-core` reference.

## Checklist

- [ ] Did you test manually the changes
